### PR TITLE
Fixed message localization config not generating.

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
@@ -68,7 +68,7 @@ public class DiscordIntegration {
     @Mod.EventHandler
     public void modConstruction(FMLConstructionEvent ev) {
         try {
-            Configuration.instance().loadConfig();
+            Discord.loadConfigs();
             if (!Configuration.instance().general.botToken.equals("INSERT BOT TOKEN HERE")) { //Prevent events when token not set
                 MinecraftForge.EVENT_BUS.register(this);
             } else {


### PR DESCRIPTION
This change had been made in 1.19 but was not made in 1.12 along with the other changes for the switch to an independent localization file.