### PR TITLE
fix: update Forge mod manifest to match actual Forge version used

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -29,6 +29,6 @@ side = "SERVER"
 [[dependencies.dcintegration]]
 modId = "forge"
 mandatory = true
-versionRange = "[44.0.37,)"
+versionRange = "[43.2.0,)"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
otherwise, the mod won't load on servers running Minecraft 1.19.2 and Forge 43.2.x