### PR TITLE
feat: add role color/hover/click formatting to reaction messages

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/util/ForgeServerInterface.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/util/ForgeServerInterface.java
@@ -3,6 +3,7 @@ package de.erdbeerbaerlp.dcintegration.forge.util;
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import dcshadow.com.vdurmont.emoji.EmojiParser;
 import dcshadow.dev.vankka.mcdiscordreserializer.minecraft.MinecraftSerializer;
 import dcshadow.net.kyori.adventure.text.Component;
 import dcshadow.net.kyori.adventure.text.TextReplacementConfig;
@@ -23,6 +24,7 @@ import de.erdbeerbaerlp.dcintegration.forge.command.DCCommandSender;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.entities.emoji.EmojiUnion;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -82,7 +84,7 @@ public class ForgeServerInterface implements ServerInterface {
         final List<ServerPlayer> l = ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers();
         for (final ServerPlayer p : l) {
             if (p.getUUID().equals(targetUUID) && !Variables.discord_instance.ignoringPlayers.contains(p.getUUID()) && !PlayerLinkController.getSettings(null, p.getUUID()).ignoreDiscordChatIngame && !PlayerLinkController.getSettings(null, p.getUUID()).ignoreReactions) {
-                final String emote = ":" + reactionEmote.getName() + ":";
+                final String emote = reactionEmote.getType() == Emoji.Type.UNICODE ? EmojiParser.parseToAliases(reactionEmote.getName()) : ":" + reactionEmote.getName() + ":";
 
                 Style.Builder memberStyle = Style.style();
                 if (Configuration.instance().messages.discordRoleColorIngame)

--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/util/ForgeServerInterface.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/util/ForgeServerInterface.java
@@ -5,7 +5,13 @@ import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dcshadow.dev.vankka.mcdiscordreserializer.minecraft.MinecraftSerializer;
 import dcshadow.net.kyori.adventure.text.Component;
+import dcshadow.net.kyori.adventure.text.TextReplacementConfig;
+import dcshadow.net.kyori.adventure.text.event.ClickEvent;
+import dcshadow.net.kyori.adventure.text.event.HoverEvent;
+import dcshadow.net.kyori.adventure.text.format.Style;
+import dcshadow.net.kyori.adventure.text.format.TextColor;
 import dcshadow.net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import dcshadow.net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import de.erdbeerbaerlp.dcintegration.common.DiscordEventListener;
 import de.erdbeerbaerlp.dcintegration.common.storage.Configuration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Localization;
@@ -76,15 +82,28 @@ public class ForgeServerInterface implements ServerInterface {
         final List<ServerPlayer> l = ServerLifecycleHooks.getCurrentServer().getPlayerList().getPlayers();
         for (final ServerPlayer p : l) {
             if (p.getUUID().equals(targetUUID) && !Variables.discord_instance.ignoringPlayers.contains(p.getUUID()) && !PlayerLinkController.getSettings(null, p.getUUID()).ignoreDiscordChatIngame && !PlayerLinkController.getSettings(null, p.getUUID()).ignoreReactions) {
+                final String emote = ":" + reactionEmote.getName() + ":";
 
-                final String emote =  ":" + reactionEmote.getName() + ":";
-                String outMsg = Localization.instance().reactionMessage.replace("%name%", member.getEffectiveName()).replace("%name2%", member.getUser().getAsTag()).replace("%emote%", emote);
+                Style.Builder memberStyle = Style.style();
+                if (Configuration.instance().messages.discordRoleColorIngame)
+                    memberStyle = memberStyle.color(TextColor.color(member.getColorRaw()));
+
+                final Component user = Component.text(member.getEffectiveName()).style(memberStyle
+                        .clickEvent(ClickEvent.suggestCommand("<@" + member.getId() + ">"))
+                        .hoverEvent(HoverEvent.showText(Component.text(Localization.instance().discordUserHover.replace("%user#tag%", member.getUser().getAsTag()).replace("%user%", member.getEffectiveName()).replace("%id%", member.getUser().getId())))));
+                final TextReplacementConfig userReplacer = ComponentUtils.replaceLiteral("%user%", user);
+                final TextReplacementConfig emoteReplacer = ComponentUtils.replaceLiteral("%emote%", emote);
+
+                final Component out = LegacyComponentSerializer.legacySection().deserialize(Localization.instance().reactionMessage)
+                        .replaceText(userReplacer).replaceText(emoteReplacer);
+
                 if (Localization.instance().reactionMessage.contains("%msg%"))
                     retrieveMessage.submit().thenAccept((m) -> {
-                        String outMsg2 = outMsg.replace("%msg%", m.getContentDisplay());
-                        sendReactionMCMessage(p, ForgeMessageUtils.formatEmoteMessage(m.getMentions().getCustomEmojis(), outMsg2));
+                        final String msg = ForgeMessageUtils.formatEmoteMessage(m.getMentions().getCustomEmojis(), m.getContentDisplay());
+                        final TextReplacementConfig msgReplacer = ComponentUtils.replaceLiteral("%msg%", msg);
+                        sendReactionMCMessage(p, out.replaceText(msgReplacer));
                     });
-                else sendReactionMCMessage(p, outMsg);
+                else sendReactionMCMessage(p, out);
             }
         }
     }
@@ -130,8 +149,7 @@ public class ForgeServerInterface implements ServerInterface {
         return "Forge";
     }
 
-    private void sendReactionMCMessage(ServerPlayer target, String msg) {
-        final Component msgComp = MinecraftSerializer.INSTANCE.serialize(msg.replace("\n", "\\n"), DiscordEventListener.mcSerializerOptions);
+    private void sendReactionMCMessage(ServerPlayer target, Component msgComp) {
         final String jsonComp = GsonComponentSerializer.gson().serialize(msgComp).replace("\\\\n", "\n");
         try {
             final net.minecraft.network.chat.Component comp = ComponentArgument.textComponent().parse(new StringReader(jsonComp));


### PR DESCRIPTION
currently, the nicknames of Discord users that react to message show up as plain, unformatted text

these commits will format them just like normal messages coming from Discord

(will probably need to do this for Spigot/Fabric mods, + update the help text for the `reactionMessage` localization config to reflect the changed placeholder(s))