### PR TITLE
Optimize order of checks for onDeath.

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
@@ -358,8 +358,8 @@ public class DiscordIntegration {
     @SubscribeEvent
     public void death(LivingDeathEvent ev) {
         if (Localization.instance().playerDeath.isBlank()) return;
-        if (PlayerLinkController.getSettings(null, ev.getEntity().getUUID()).hideFromDiscord) return;
-        if (ev.getEntity() instanceof Player || (ev.getEntity() instanceof TamableAnimal && ((TamableAnimal) ev.getEntity()).getOwner() instanceof Player && Configuration.instance().messages.sendDeathMessagesForTamedAnimals)) {
+        if ((ev.getEntity() instanceof Player && !PlayerLinkController.getSettings(null, ev.getEntity().getUUID()).hideFromDiscord)
+                || (ev.getEntity() instanceof TamableAnimal && ((TamableAnimal) ev.getEntity()).getOwner() instanceof Player && Configuration.instance().messages.sendDeathMessagesForTamedAnimals)) {
             if (discord_instance != null) {
                 final net.minecraft.network.chat.Component deathMessage = ev.getSource().getLocalizedDeathMessage(ev.getEntityLiving());
                 final MessageEmbed embed = ForgeMessageUtils.genItemStackEmbedIfAvailable(deathMessage);


### PR DESCRIPTION
Drastically decreases needless/(known default) calls to PlayerLinkController.GetSettings(*) for any non-Player LivingEntity.

As before any death of any living entity would trigger a call to PlayerLinkController.GetSettings(*). Which in turn would call the global linking API (if enabled)