### PR TITLE
Ignore cancelled chat events

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/forge/DiscordIntegration.java
@@ -35,6 +35,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.*;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import org.apache.commons.lang3.ArrayUtils;
@@ -285,8 +286,9 @@ public class DiscordIntegration {
         return ArrayUtils.contains(Configuration.instance().forgeSpecific.IMC_modIdBlacklist, sender);
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public void chat(ServerChatEvent ev) {
+        if (ev.isCanceled()) return;
         if (PlayerLinkController.getSettings(null, ev.getPlayer().getUniqueID()).hideFromDiscord) return;
         final ITextComponent msg = ev.getComponent();
         if (discord_instance.callEvent((e) -> {


### PR DESCRIPTION
Ignore cancelled chat events by setting the ServerChatEvent priority to lowest and checking if the event was cancelled.

Fixes #555 
